### PR TITLE
add labels for the blank-issue-form-with-no-dependancy issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue-form-with-no-dependency.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form-with-no-dependency.yml
@@ -1,5 +1,6 @@
 name: 'Blank Issue Form with No Dependency'
 description: 'Standard HackforLA issue form with no dependency'
+labels: ['role missing', 'Complexity: Missing', 'Feature Missing', 'size: missing','Draft']
 
 body:
   - type: input


### PR DESCRIPTION
Fixes #4485

### What changes did you make and why did you make them ?

  - Replace the following line
labels: ['role: design']
with
label: ['role: design','Feature Missing','Complexity: Missing','size: missing']
  - add the labels from the [Missing series](https://github.com/hackforla/website/wiki/How-to-read-and-interpret-labels#missing-series) so that we can avoid the GitHub bot taking off the labels when devs add them to issues.
