### PR TITLE
Revert "add labels for the blank-issue-form-with-no-dependancy issue template"

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue-form-with-no-dependency.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form-with-no-dependency.yml
@@ -1,6 +1,5 @@
 name: 'Blank Issue Form with No Dependency'
 description: 'Standard HackforLA issue form with no dependency'
-labels: ['role missing', 'Complexity: Missing', 'Feature Missing', 'size: missing','Draft']
 
 body:
   - type: input


### PR DESCRIPTION
Reverts rdhmdhl/website#1
Hey Reid, could you delete this pr we're concerned it might confuse other devs who might pick up the issue.